### PR TITLE
Add a missing break statement in code samples

### DIFF
--- a/content/blog_posts/articles/kysely-with-adonisjs.md
+++ b/content/blog_posts/articles/kysely-with-adonisjs.md
@@ -236,6 +236,7 @@ export default class KyselyMigrate extends BaseCommand {
           break
         case 'Error':
           this.logger.error(`failed to execute migration "${it.migrationName}"`)
+          break
         case 'NotExecuted':
           this.logger.info(`migration pending "${it.migrationName}"`)
       }
@@ -327,6 +328,7 @@ export default class KyselyRollback extends BaseCommand {
           break
         case 'Error':
           this.logger.error(`failed to rollback migration "${it.migrationName}"`)
+          break
         case 'NotExecuted':
           this.logger.info(`rollback pending "${it.migrationName}"`)
       }


### PR DESCRIPTION
While following this article, I copied and pasted the code samples for migration commands. However, I encountered an error regarding a missing break statement. It's a simple fix, but it can be annoying.
![Screenshot from 2024-02-17 13-44-34](https://github.com/adonisjs/adonisjs.com/assets/43722815/9829ccb4-b7a9-4a0c-b6f6-e7496e26cb2d)
