### PR TITLE
refactor: update HMR documentation link

### DIFF
--- a/content/blog_posts/articles/hmr-in-adonisjs.md
+++ b/content/blog_posts/articles/hmr-in-adonisjs.md
@@ -50,7 +50,7 @@ Note that you no longer need the `--watch` flag. Only `--hmr` is enough. If you 
 
 Now, try modifying a controller. You will see that the server does not restart, but the modifications will be considered: you'll always have the latest version of your code.
 
-For more information, please consult the [official documentation](https://docs.adonisjs.com/guides/hot-module-reloading).
+For more information, please consult the [official documentation](https://docs.adonisjs.com/guides/concepts/hot-module-replacement).
 
 ## Backstory
 


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

The current link for "Hot Module Replacement documentation" takes the user to a broken link. The documentation for HMR https://docs.adonisjs.com/guides/hot-module-reloading must have been moved but never updated. I searched the docs and found a section with a similar URL, that works and created an update for it

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
